### PR TITLE
Fix small typo in labo 6

### DIFF
--- a/content/teaching/cpp/labo-6.md
+++ b/content/teaching/cpp/labo-6.md
@@ -318,7 +318,7 @@ graph TD;
   subgraph source code
     H[header.h<br/> template definitie van Punt]
     A[source1.cpp<br/> gebruik Punt van int]
-    B[source2.cp<br/> gebruik Punt van int]
+    B[source2.cpp<br/> gebruik Punt van int]
     A --> H
     B --> H
   end


### PR DESCRIPTION
.cp -> .cpp