### PR TITLE
changed "eerste" en "laatste"

### DIFF
--- a/docs/teaching/cpp/labo-3/index.html
+++ b/docs/teaching/cpp/labo-3/index.html
@@ -267,7 +267,7 @@
 
 <h3 id="display-setup">Display setup</h3>
 
-<p>Er zijn 6 verschillende &ldquo;Video Modes&rdquo; beschikbaar die je moet aan- of uitzetten voordat je iets kan tekenen op het scherm. De GBA ondersteunt tilesets om sprites efficiënter te tekenen (de 3 laatste modes), maar wij hebben voorlopig genoeg aan pixel per pixel de kleur te zetten (de 3 eerste modes). De eenvoudigste mode zonder buffering is <strong>video mode 3</strong>. Dit heeft een resolutie van 240x160. Elke pixel RGB waardes om aan te spreken.</p>
+<p>Er zijn 6 verschillende &ldquo;Video Modes&rdquo; beschikbaar die je moet aan- of uitzetten voordat je iets kan tekenen op het scherm. De GBA ondersteunt tilesets om sprites efficiënter te tekenen (de 3 eerste modes), maar wij hebben voorlopig genoeg aan pixel per pixel de kleur te zetten (de 3 laatste modes). De eenvoudigste mode zonder buffering is <strong>video mode 3</strong>. Dit heeft een resolutie van 240x160. Elke pixel RGB waardes om aan te spreken.</p>
 
 <p>Naast mode 3 moeten we ook een &ldquo;Background mode&rdquo; kiezen. Er zijn 4 achtergrond lagen beschikbaar die het mogelijk maken om een 3D illusie te creëren door laag per laag te tekenen. BG mode 2 volstaat voorlopig.</p>
 


### PR DESCRIPTION
regel 270 
De GBA ondersteunt tilesets om sprites efficiënter te tekenen (de 3 laatste->eerste modes)
maar wij hebben voorlopig genoeg aan pixel per pixel de kleur te zetten (de 3 eerste-> laatste modes)